### PR TITLE
fix: node binaries path check

### DIFF
--- a/lib/node_starter.rb
+++ b/lib/node_starter.rb
@@ -5,7 +5,6 @@ require 'node_starter/database'
 require 'sidekiq'
 require 'node_starter/workers/starter'
 
-
 # Namespace that handles git operations for NodeStarter
 module NodeStarter
   class << self
@@ -17,6 +16,7 @@ module NodeStarter
     def logger=(l)
       @logger = l
     end
+
     # rubocop:enable TrivialAccessors
     def config
       @config ||= NodeStarter::Config.new

--- a/lib/node_starter/prepare_binaries.rb
+++ b/lib/node_starter/prepare_binaries.rb
@@ -3,6 +3,9 @@ module NodeStarter
   class PrepareBinaries
     class << self
       def write_to(path)
+        fail 'Configured node_binaries_path is not a directory.' unless
+          File.directory? NodeStarter.config.node_binaries_path
+
         FileUtils.cp_r("#{NodeStarter.config.node_binaries_path}/.", path)
       end
     end

--- a/spec/integration/queue_subscribe_spec.rb
+++ b/spec/integration/queue_subscribe_spec.rb
@@ -25,6 +25,7 @@ describe 'NodeStarter::Subscribe integration' do
 
   it 'starts node process' do
     expect(NodeStarter::Consumer).to receive(:new) { fake_consumer }
+    allow(NodeStarter::PrepareBinaries).to receive(:write_to)
 
     expect_any_instance_of(NodeStarter::Starter)
       .to receive(:start).with(any_args).and_return(111)

--- a/spec/unit/lib/node_starter/prepare_binaries_spec.rb
+++ b/spec/unit/lib/node_starter/prepare_binaries_spec.rb
@@ -1,0 +1,11 @@
+describe NodeStarter::PrepareBinaries do
+  context 'node_binaries_path does not exist' do
+    describe '#write_to' do
+      it 'fails with an error message' do
+        expect(File).to receive(:directory?) { false }
+        message = 'Configured node_binaries_path is not a directory.'
+        expect { NodeStarter::PrepareBinaries.write_to('bad_path') }.to raise_error message
+      end
+    end
+  end
+end

--- a/spec/unit/lib/node_starter/starter_spec.rb
+++ b/spec/unit/lib/node_starter/starter_spec.rb
@@ -5,11 +5,11 @@ describe NodeStarter::Starter do
 
   before(:each) do
     allow(subject).to receive(:start).and_return(0)
+    allow(NodeStarter::PrepareBinaries).to receive(:write_to)
   end
 
   describe '#spawn_process' do
     it 'prepares binaries' do
-      allow(NodeStarter::PrepareBinaries).to receive(:write_to)
       subject.schedule_spawn_process
       FileUtils.rm_rf(subject.dir)
     end


### PR DESCRIPTION
Mocked file-system access in specs. PrepareBinaries tries to create the binaries folder if it does not exist.