### PR TITLE
feat: generate node api address

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ Metrics/LineLength:
   Max: 100
 
 Metrics/AbcSize:
-  Max: 27
+  Max: 28
 
 AllCops:
   Exclude:

--- a/spec/unit/lib/node_starter/killer_spec.rb
+++ b/spec/unit/lib/node_starter/killer_spec.rb
@@ -37,7 +37,8 @@ describe NodeStarter::Killer do
     before(:each) do
       subject.send :instance_variable_set, '@pid', 1
       allow(subject).to receive(:sleep)
-      allow(NodeStarter.config).to receive(:shutdown_node_check_count) { 2 }
+      NodeStarter.config['shutdown_node_check_count'] = 2
+      NodeStarter.config['shutdown_node_period_in_minutes'] = 1
     end
 
     it 'fails if node api was not called first' do


### PR DESCRIPTION
node starter now generates the node's uuid and builds it's api address using machine's ip